### PR TITLE
Restrictions

### DIFF
--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -573,6 +573,22 @@ def test_restrictions_map():
         yield e._shutdown()
     _test_cluster(f)
 
+def test_restrictions_get():
+    @gen.coroutine
+    def f(c, a, b):
+        e = Executor((c.ip, c.port), start=False)
+        IOLoop.current().spawn_callback(e._go)
+
+        dsk = {'x': 1, 'y': (inc, 'x'), 'z': (inc, 'y')}
+        restrictions = {'y': {a.address}, 'z': {b.address}}
+
+        result = yield e._get(dsk, 'z', restrictions)
+        assert result == 3
+        assert 'y' in a.data
+        assert 'z' in b.data
+
+        yield e._shutdown()
+    _test_cluster(f)
 
 def dont_test_bad_restrictions_raise_exception():
     @gen.coroutine


### PR DESCRIPTION
Fixes #5 cc @seibert

Also cc @quasiben, distributed is now ready for your HDFS shenanigans.

This allows users to provide a set of workers onto which the computation should be restricted

```python
>>> e.submit(inc, 1, workers={('alice', 8788), ('bob', 8788)})
>>> e.map(inc, range(5), workers={('alice', 8788), ('bob', 8788)})
>>> e.map(inc, range(5), workers=[{('alice-%s' % i, 8788)} for i in range(5)])
>>> e.get(dsk, keys, {'x': {('alice', 8788)}, 'y': {('bob', 8788), ('charlie', 8788)}})
```

When nothing is provided it's assumed that the job can happen anywhere.  I should probably follow this up with some sort of normalization so that we allow names like `alice:8788` or, as @seibert suggested, some sort of worker namespace.