### PR TITLE
Various fixes

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -7,6 +7,7 @@ import struct
 from time import sleep, time
 
 import tornado
+import dill
 from dill import loads, dumps
 from tornado import ioloop, gen
 from tornado.gen import Return
@@ -14,6 +15,8 @@ from tornado.tcpserver import TCPServer
 from tornado.tcpclient import TCPClient
 from tornado.ioloop import IOLoop
 from tornado.iostream import IOStream, StreamClosedError
+
+dill.settings['recurse'] = True
 
 
 logger = logging.getLogger(__name__)

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -131,6 +131,8 @@ class Executor(object):
 
     def start(self):
         """ Start scheduler running in separate thread """
+        if hasattr(self, '_loop_thread'):
+            return
         from threading import Thread
         self._loop_thread = Thread(target=self.loop.start)
         self._loop_thread.start()

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -545,3 +545,20 @@ def as_completed(fs):
 
     for i in range(len(fs)):
         yield queue.get()
+
+
+def default_executor(e=None):
+    """ Return an executor if exactly one has started """
+    if e:
+        return e
+    if len(_global_executors) == 1:
+        return first(_global_executors)
+    if len(_global_executors) == 0:
+        raise ValueError("No executors found\n"
+                "Start an executor and point it to the center address\n"
+                "  from distributed import Executor\n"
+                "  executor = Executor('ip-addr-of-center:8787')\n")
+    if len(_global_executors) > 1:
+        raise ValueError("There are %d executors running.\n"
+            "Please specify which executor you want with the executor= \n"
+            "keyword argument." % len(_global_executors))

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -137,7 +137,7 @@ class Executor(object):
         if hasattr(self, '_loop_thread'):
             return
         from threading import Thread
-        self._loop_thread = Thread(target=self.loop.start)
+        self._loop_thread = Thread(target=self.loop.start, daemon=True)
         _global_executors.add(self)
         self._loop_thread.start()
         sync(self.loop, self._sync_center)

--- a/distributed/tests/test_dask.py
+++ b/distributed/tests/test_dask.py
@@ -134,8 +134,8 @@ def dont_test_failing_worker():
 
 
 def test_repeated_computation():
+    from random import randint
     def func():
-        from random import randint
         return randint(0, 100)
 
     dsk = {'x': (func,)}

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -10,7 +10,7 @@ from tornado.ioloop import IOLoop
 from tornado import gen
 
 from distributed.executor import (Executor, Future, _wait, wait, _as_completed,
-        as_completed, tokenize)
+        as_completed, tokenize, _global_executors)
 from distributed.client import WrappedKey
 from distributed import Center, Worker
 from distributed.utils import ignoring
@@ -142,7 +142,6 @@ def test_submit_naming():
 
         c = e.submit(inc, 1, pure=False)
         assert c.key != a.key
-
     _test_cluster(f)
 
 
@@ -165,7 +164,6 @@ def test_exceptions():
         assert result == 10 / 2
 
         yield e._shutdown()
-
     _test_cluster(f)
 
 
@@ -184,7 +182,7 @@ def test_gc():
         yield e._shutdown()
 
         assert not c.who_has[x.key]
-
+        yield e._shutdown()
     _test_cluster(f)
 
 
@@ -391,6 +389,7 @@ def test_garbage_collection():
         bkey = b.key
         b.__del__()
         assert bkey not in e.futures
+        yield e._shutdown()
 
     _test_cluster(f)
 
@@ -416,6 +415,7 @@ def test_recompute_released_key():
         assert x.key in e.futures
         result2 = yield x._result()
         assert result1 == result2
+        yield e._shutdown()
 
     _test_cluster(f)
 
@@ -473,6 +473,7 @@ def test_missing_data_heals():
 
         result = yield w._result()
         assert result == 3 + 4
+        yield e._shutdown()
 
     _test_cluster(f)
 
@@ -866,3 +867,12 @@ def test_get_releases_data():
 
         yield e._shutdown()
     _test_cluster(f)
+
+
+def test_global_executors():
+    assert not _global_executors
+    with cluster() as (c, [a, b]):
+        with Executor(('127.0.0.1', c['port'])) as e:
+            assert _global_executors == {e}
+
+    assert not _global_executors


### PR DESCRIPTION
This is from a conversation with @freeman-lab and @jcrist

- [x] executor.start idempotent
- [x] global executor
- [x] background thread set as daemon
- [x] set dill `recurse=True` option by default
- [ ] propagate exceptions (I had this in a branch but stopped work.  This is why I was confused about current functionality)
- [ ] log exceptions loudly, possibly to screen