### PR TITLE
Make scheduler data-size aware

### DIFF
--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -7,3 +7,8 @@ if sys.version_info[0] == 2:
 
 if sys.version_info[0] == 3:
     from queue import Queue
+
+try:
+    from functools import singledispatch
+except ImportError:
+    from singledispatch import singledispatch

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -144,6 +144,13 @@ class Executor(object):
         sync(self.loop, self._sync_center)
         self.loop.add_callback(self._go)
 
+    @gen.coroutine
+    def _start(self):
+        yield self._sync_center()
+        IOLoop.current().spawn_callback(self._go)
+        while not len(self.stacks) == len(self.ncores):
+            yield gen.sleep(0.01)
+
     def __enter__(self):
         if not self.loop._running:
             self.start()
@@ -221,7 +228,6 @@ class Executor(object):
     @gen.coroutine
     def _go(self):
         """ Setup and run all other coroutines.  Block until finished. """
-        yield self._sync_center()
         worker_queues = {worker: Queue() for worker in self.ncores}
         delete_queue = Queue()
 

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -291,10 +291,10 @@ class Executor(object):
         if key in self.futures:
             return Future(key, self)
 
-        args = quote(args)
+        args = tuple(map(quote, args))
 
         if kwargs:
-            task = (apply, func, args, kwargs)
+            task = (apply, func, (tuple, list(args)), kwargs)
         else:
             task = (func,) + args
 
@@ -359,7 +359,7 @@ class Executor(object):
             dsk = {key: (func,) + tuple(map(quote, args))
                    for key, args in zip(keys, zip(*iterables))}
         else:
-            dsk = {key: (apply, func, args, kwargs)
+            dsk = {key: (apply, func, (tuple, list(map(quote, args))), kwargs)
                    for key, args in zip(keys, zip(*iterables))}
 
         for key in dsk:

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -20,10 +20,11 @@ from tornado.ioloop import IOLoop
 from tornado.iostream import StreamClosedError
 from tornado.queues import Queue
 
-from .core import read, write, connect, rpc, coerce_to_rpc
 from .client import (WrappedKey, _gather, unpack_remotedata, pack_data,
         scatter_to_workers)
+from .core import read, write, connect, rpc, coerce_to_rpc
 from .dask import scheduler, worker, delete
+from .sizeof import sizeof
 from .utils import All, sync, funcname
 
 logger = logging.getLogger(__name__)

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -291,10 +291,8 @@ class Executor(object):
         if key in self.futures:
             return Future(key, self)
 
-        args = tuple(map(quote, args))
-
         if kwargs:
-            task = (apply, func, (tuple, list(args)), kwargs)
+            task = (apply, func, args, kwargs)
         else:
             task = (func,) + args
 
@@ -356,10 +354,10 @@ class Executor(object):
                     for i in range(min(map(len, iterables)))]
 
         if not kwargs:
-            dsk = {key: (func,) + tuple(map(quote, args))
+            dsk = {key: (func,) + args
                    for key, args in zip(keys, zip(*iterables))}
         else:
-            dsk = {key: (apply, func, (tuple, list(map(quote, args))), kwargs)
+            dsk = {key: (apply, func, args, kwargs)
                    for key, args in zip(keys, zip(*iterables))}
 
         for key in dsk:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -220,7 +220,7 @@ def scheduler(scheduler_queue, report_queue, worker_queues, delete_queue,
             del waiting[key]
 
         new_worker = decide_worker(dependencies, stacks, who_has, restrictions,
-                nbytes, key)
+                                   nbytes, key)
         stacks[new_worker].append(key)
         ensure_occupied(new_worker)
 
@@ -850,7 +850,7 @@ def cover_aliases(dsk, new_keys):
 
 
 def execute_task(task):
-    """ Do the actual work of collecting data and executing a function """
+    """ Evaluate a nested task """
     if istask(task):
         func, args = task[0], task[1:]
         return func(*map(execute_task, args))

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -13,7 +13,6 @@ from tornado.queues import Queue
 from tornado.ioloop import IOLoop
 from tornado.iostream import StreamClosedError
 
-from dask.async import _execute_task
 from dask.core import istask, get_deps, reverse_dict, get_dependencies
 from dask.order import order
 
@@ -848,3 +847,12 @@ def cover_aliases(dsk, new_keys):
             pass
 
     return dsk
+
+
+def execute_task(task):
+    """ Do the actual work of collecting data and executing a function """
+    if istask(task):
+        func, args = task[0], task[1:]
+        return func(*map(execute_task, args))
+    else:
+        return task

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -33,9 +33,6 @@ with ignoring(ImportError):
     @sizeof.register(pd.Series)
     def _(s):
         try:
-            return s.memory_usage(index=True, deep=True).sum()
+            return s.memory_usage(index=True, deep=True).sum() # new in 0.17.1
         except:
-            try:
-                return s.memory_usage(index=True).sum()
-            except:
-                return sizeof(s.values) + sizeof(s.index)
+            return sizeof(s.values) + sizeof(s.index)

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -1,0 +1,32 @@
+import sys
+from .compatibility import singledispatch
+from .utils import ignoring
+
+@singledispatch
+def sizeof(o):
+    return sys.getsizeof(o)
+
+@sizeof.register(list)
+@sizeof.register(tuple)
+@sizeof.register(set)
+@sizeof.register(frozenset)
+def _(seq):
+    return sys.getsizeof(seq) + sum(map(sizeof, seq))
+
+
+with ignoring(ImportError):
+    import pandas as pd
+    @sizeof.register(pd.DataFrame)
+    def _(df):
+        try:
+            return df.memory_usage(index=True, deep=True).sum()
+        except:
+            return df.memory_usage(index=True).sum()
+
+    @sizeof.register(pd.Series)
+    def _(s):
+        try:
+            return s.memory_usage(index=True, deep=True).sum()
+        except:
+            return s.memory_usage(index=True).sum()
+            return s.values.nbytes

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -35,7 +35,7 @@ def test__futures_to_dask_dataframe():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         remote_dfs = e.map(lambda x: x, dfs)
         ddf = yield _futures_to_dask_dataframe(remote_dfs, divisions=True,
@@ -98,7 +98,7 @@ def test__futures_to_dask_array():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         remote_arrays = [[[e.submit(np.full, (2, 3, 4), i + j + k)
                             for i in range(2)]
@@ -123,8 +123,7 @@ def test__dask_array_collections():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
-        yield e._sync_center()
+        yield e._start()
 
         x_dsk = {('x', i, j): np.random.random((3, 3)) for i in range(3)
                                                        for j in range(2)}

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -743,12 +743,9 @@ def test_submit_quotes():
 
         x = e.submit(inc, 1)
         y = e.submit(inc, 2)
-        z = e.submit(sum, [x, y])
-        yield z._result()
-
-        task = e.dask[z.key]
-        assert task[0] == sum
-        assert istask(task[1])
+        z = e.submit(assert_list, [x, y])
+        result = yield z._result()
+        assert result
 
         yield e._shutdown()
     _test_cluster(f)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -9,7 +9,6 @@ from toolz import identity, isdistinct, first
 from tornado.ioloop import IOLoop
 from tornado import gen
 
-from dask import istask
 from distributed import Center, Worker
 from distributed.client import WrappedKey
 from distributed.executor import (Executor, Future, _wait, wait, _as_completed,

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -34,7 +34,8 @@ def test_submit():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
+
         x = e.submit(inc, 10)
         assert not x.done()
 
@@ -58,7 +59,7 @@ def test_map():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         L1 = e.map(inc, range(5))
         assert len(L1) == 5
@@ -150,7 +151,7 @@ def test_exceptions():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x = e.submit(div, 1, 2)
         result = yield x._result()
@@ -172,7 +173,8 @@ def test_gc():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
+
         x = e.submit(inc, 10)
         result = yield x._result()
 
@@ -218,7 +220,7 @@ def test_stress_1():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         n = 2**6
 
@@ -239,7 +241,8 @@ def test_gather():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
+
         x = e.submit(inc, 10)
         y = e.submit(inc, x)
 
@@ -266,7 +269,8 @@ def test_get():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
+
         result = yield e._get({'x': (inc, 1)}, 'x')
         assert result == 2
 
@@ -303,7 +307,7 @@ def test_wait():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         a = e.submit(inc, 1)
         b = e.submit(inc, 1)
@@ -324,7 +328,7 @@ def test__as_completed():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         a = e.submit(inc, 1)
         b = e.submit(inc, 1)
@@ -382,7 +386,7 @@ def test_garbage_collection():
         c = e.submit(inc, b)
         b.__del__()
 
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         result = yield c._result()
         assert result == 3
@@ -399,7 +403,7 @@ def test_recompute_released_key():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), delete_batch_time=0, start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x = e.submit(inc, 100)
         result1 = yield x._result()
@@ -442,7 +446,7 @@ def test_long_tasks_dont_trigger_timeout():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), delete_batch_time=0, start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         from time import sleep
         x = e.submit(sleep, 3)
@@ -456,7 +460,7 @@ def test_missing_data_heals():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), delete_batch_time=0, start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x = e.submit(inc, 1)
         y = e.submit(inc, x)
@@ -489,7 +493,7 @@ def test_missing_worker():
         c.has_what[bad] = {'b'}
 
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         dsk = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b')}
 
@@ -506,7 +510,7 @@ def test_gather_robust_to_missing_data():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x, y, z = e.map(inc, range(3))
         yield _wait([x, y, z])  # everything computed
@@ -529,7 +533,7 @@ def test_gather_robust_to_nested_missing_data():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         w = e.submit(inc, 1)
         x = e.submit(inc, w)
@@ -568,7 +572,7 @@ def test_restrictions_submit():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x = e.submit(inc, 1, workers={a.ip})
         y = e.submit(inc, x, workers={b.ip})
@@ -588,7 +592,7 @@ def test_restrictions_map():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         L = e.map(inc, range(5), workers={a.ip})
         yield _wait(L)
@@ -618,7 +622,7 @@ def test_restrictions_get():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         dsk = {'x': 1, 'y': (inc, 'x'), 'z': (inc, 'y')}
         restrictions = {'y': {a.ip}, 'z': {b.ip}}
@@ -636,7 +640,7 @@ def dont_test_bad_restrictions_raise_exception():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         z = e.submit(inc, 2, workers={'bad-address'})
         try:
@@ -697,7 +701,7 @@ def test_errors_dont_block():
     def f():
         c.listen(c.port)
         yield w._start()
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         L = [e.submit(inc, 1),
              e.submit(throws, 1),
@@ -726,7 +730,7 @@ def test_submit_quotes():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x = e.submit(assert_list, [1, 2, 3], z=[4, 5, 6])
         result = yield x._result()
@@ -748,7 +752,7 @@ def test_map_quotes():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         L = e.map(assert_list, [[1, 2, 3], [4]])
         result = yield e._gather(L)
@@ -767,14 +771,13 @@ def test_two_consecutive_executors_share_results():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x = e.submit(randint, 0, 1000, pure=True)
         xx = yield x._result()
 
         f = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(f._go)
-        yield f._sync_center()
+        yield f._start()
 
         y = f.submit(randint, 0, 1000, pure=True)
         yy = yield y._result()
@@ -790,7 +793,7 @@ def test_submit_then_get_with_Future():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x = e.submit(slowinc, 1)
         dsk = {'y': (inc, x)}
@@ -806,7 +809,7 @@ def test_aliases():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         x = e.submit(inc, 1)
 
@@ -827,8 +830,7 @@ def test__scatter():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
-        yield e._sync_center()
+        yield e._start()
 
         d = yield e._scatter({'y': 20})
         assert isinstance(d['y'], WrappedKey)
@@ -862,7 +864,7 @@ def test_get_releases_data():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         [x] = yield e._get({'x': (inc, 1)}, ['x'])
         import gc; gc.collect()
@@ -897,7 +899,7 @@ def test_exception_on_exception():
         x = e.submit(lambda: 1 / 0)
         y = e.submit(inc, x)
 
-        IOLoop.current().spawn_callback(e._go)
+        yield e._start()
 
         with pytest.raises(ZeroDivisionError):
             out = yield y._result()
@@ -915,8 +917,7 @@ def test_nbytes():
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
-        IOLoop.current().spawn_callback(e._go)
-        yield e._sync_center()
+        yield e._start()
 
         [x] = yield e._scatter([1])
         assert e.nbytes == {x.key: sizeof(1)}

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -286,7 +286,7 @@ def test_decide_worker_with_many_independent_leaves():
                     {('x', i * 2 + 1): {'bob'} for i in range(50)})
 
     for key in dsk:
-        worker = decide_worker(dependencies, stacks, who_has, {}, key)
+        worker = decide_worker(dependencies, stacks, who_has, {}, {}, key)
         stacks[worker].append(key)
 
     nhits = (len([k for k in stacks['alice'] if 'alice' in who_has[('x', k[1])]])
@@ -301,22 +301,23 @@ def test_decide_worker_with_restrictions():
     stacks = {alice: [], bob: [], charlie: []}
     who_has = {}
     restrictions = {'x': {'alice', 'charlie'}}
-    result = decide_worker(dependencies, stacks, who_has, restrictions, 'x')
+    nbytes = {}
+    result = decide_worker(dependencies, stacks, who_has, restrictions, nbytes, 'x')
     assert result in {alice, charlie}
 
     stacks = {alice: [1, 2, 3], bob: [], charlie: [4, 5, 6]}
-    result = decide_worker(dependencies, stacks, who_has, restrictions, 'x')
+    result = decide_worker(dependencies, stacks, who_has, restrictions, nbytes, 'x')
     assert result in {alice, charlie}
 
     dependencies = {'x': {'y'}}
     who_has = {'y': {bob}}
-    result = decide_worker(dependencies, stacks, who_has, restrictions, 'x')
+    result = decide_worker(dependencies, stacks, who_has, restrictions, nbytes, 'x')
     assert result in {alice, charlie}
 
 
 def test_decide_worker_without_stacks():
     with pytest.raises(ValueError):
-        result = decide_worker({'x': []}, [], {}, {}, 'x')
+        result = decide_worker({'x': []}, [], {}, {}, {}, 'x')
 
 
 def test_validate_state():
@@ -378,11 +379,12 @@ def test_assign_many_tasks():
     keyorder = {c: 1 for c in 'abxy'}
     who_has = {'x': {alice}}
     stacks = {alice: [], bob: []}
+    nbytes = {}
     restrictions = {}
     keys = ['y', 'a']
 
     new_stacks = assign_many_tasks(dependencies, waiting, keyorder, who_has,
-                                   stacks, restrictions, ['y', 'a'])
+                                   stacks, restrictions, nbytes, ['y', 'a'])
 
     assert 'y' in stacks[alice]
     assert 'a' in stacks[alice] + stacks[bob]
@@ -399,11 +401,12 @@ def test_assign_many_tasks_with_restrictions():
     keyorder = {c: 1 for c in 'abxy'}
     who_has = {'x': {alice}}
     stacks = {alice: [], bob: []}
+    nbytes = {}
     restrictions = {'y': {'bob'}, 'a': {'alice'}}
     keys = ['y', 'a']
 
     new_stacks = assign_many_tasks(dependencies, waiting, keyorder, who_has,
-                                   stacks, restrictions, ['y', 'a'])
+                                   stacks, restrictions, nbytes, ['y', 'a'])
 
     assert 'y' in stacks[bob]
     assert 'a' in stacks[alice]

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -284,9 +284,10 @@ def test_decide_worker_with_many_independent_leaves():
     stacks = {'alice': [], 'bob': []}
     who_has = merge({('x', i * 2): {'alice'} for i in range(50)},
                     {('x', i * 2 + 1): {'bob'} for i in range(50)})
+    nbytes = {k: 0 for k in who_has}
 
     for key in dsk:
-        worker = decide_worker(dependencies, stacks, who_has, {}, {}, key)
+        worker = decide_worker(dependencies, stacks, who_has, {}, nbytes, key)
         stacks[worker].append(key)
 
     nhits = (len([k for k in stacks['alice'] if 'alice' in who_has[('x', k[1])]])
@@ -311,6 +312,7 @@ def test_decide_worker_with_restrictions():
 
     dependencies = {'x': {'y'}}
     who_has = {'y': {bob}}
+    nbytes = {'y': 0}
     result = decide_worker(dependencies, stacks, who_has, restrictions, nbytes, 'x')
     assert result in {alice, charlie}
 
@@ -401,7 +403,7 @@ def test_assign_many_tasks_with_restrictions():
     keyorder = {c: 1 for c in 'abxy'}
     who_has = {'x': {alice}}
     stacks = {alice: [], bob: []}
-    nbytes = {}
+    nbytes = {'x': 0}
     restrictions = {'y': {'bob'}, 'a': {'alice'}}
     keys = ['y', 'a']
 

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -1,0 +1,30 @@
+import sys
+
+import pytest
+
+from distributed.sizeof import sizeof
+
+
+def test_base():
+    assert sizeof(1) == sys.getsizeof(1)
+
+
+def test_containers():
+    assert sizeof([1, 2, [3]]) > (sys.getsizeof(3) * 3 + sys.getsizeof([]))
+
+
+def test_numpy():
+    np = pytest.importorskip('numpy')
+    assert sizeof(np.empty(1000, dtype='f8')) >= 8000
+
+
+def test_pandas():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a'*1000, 'b'*1000, 'c'*1000]},
+                      index=[10, 20, 30])
+
+    # TODO: change these once pandas memory_usage improves (in PR as of now)
+    assert sizeof(df) >= sizeof(df.x) + sizeof(df.y) - sizeof(df.index)
+    assert sizeof(df.x) >= sizeof(df.index)
+    # assert sizeof(df.y) >= 1000 * 3
+    assert sizeof(df.index) == 56

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -23,8 +23,8 @@ def test_pandas():
     df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a'*1000, 'b'*1000, 'c'*1000]},
                       index=[10, 20, 30])
 
-    # TODO: change these once pandas memory_usage improves (in PR as of now)
     assert sizeof(df) >= sizeof(df.x) + sizeof(df.y) - sizeof(df.index)
     assert sizeof(df.x) >= sizeof(df.index)
-    # assert sizeof(df.y) >= 1000 * 3
+    if pd.__version__ >= '0.17.1':
+        assert sizeof(df.y) >= 1000 * 3
     assert sizeof(df.index) == 56

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -90,7 +90,9 @@ def test_workers_update_center():
     def f(c, a, b):
         aa = rpc(ip=a.ip, port=a.port)
 
-        yield aa.update_data(data={'x': 1, 'y': 2})
+        response, content = yield aa.update_data(data={'x': 1, 'y': 2})
+        assert response == b'OK'
+        assert content['nbytes'] == {'x': sizeof(1), 'y': sizeof(2)}
 
         assert a.data == {'x': 1, 'y': 2}
         assert c.who_has == {'x': {(a.ip, a.port)},

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1,9 +1,10 @@
 from operator import add
 from time import sleep
 
-from distributed.core import read, write, rpc, connect
-from distributed.utils import ignoring
 from distributed.center import Center
+from distributed.core import read, write, rpc, connect
+from distributed.sizeof import sizeof
+from distributed.utils import ignoring
 from distributed.worker import Worker
 
 
@@ -35,6 +36,7 @@ def _test_cluster(f):
 
     IOLoop.current().run_sync(g)
 
+
 def test_worker_ncores():
     from distributed.worker import _ncores
     w = Worker('127.0.0.1', 8018, '127.0.0.1', 8019)
@@ -55,11 +57,12 @@ def test_worker():
         assert a.data['x'] == 3
         assert c.who_has['x'] == set([(a.ip, a.port)])
 
-        response, _ = yield bb.compute(key='y', function=add,
-                                       args=['x', 10], needed=['x'])
+        response, info = yield bb.compute(key='y', function=add,
+                                          args=['x', 10], needed=['x'])
         assert response == b'OK'
         assert b.data['y'] == 13
         assert c.who_has['y'] == set([(b.ip, b.port)])
+        assert info['nbytes'] == sizeof(b.data['y'])
 
         def bad_func():
             1 / 0

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -83,6 +83,7 @@ from tornado.ioloop import IOLoop
 def _test_cluster(f):
     from .center import Center
     from .worker import Worker
+    from .executor import _global_executors
     @gen.coroutine
     def g():
         c = Center('127.0.0.1', 8017)
@@ -107,3 +108,4 @@ def _test_cluster(f):
     IOLoop.clear_instance()
     loop = IOLoop().current()
     loop.run_sync(g)
+    _global_executors.clear()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -177,7 +177,8 @@ class Worker(Server):
             response = yield self.center.add_keys(address=(self.ip, self.port),
                                                   keys=list(data))
             assert response == b'OK'
-        raise Return(b'OK')
+        info = {'nbytes': {k: sizeof(v) for k, v in data.items()}}
+        raise Return((b'OK', info))
 
     @gen.coroutine
     def delete_data(self, stream, keys=None, report=True):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -12,8 +12,9 @@ from tornado.gen import Return
 from tornado import gen
 from tornado.ioloop import IOLoop
 
-from .core import rpc, connect_sync, read_sync, write_sync, connect, Server
 from .client import _gather, pack_data
+from .core import rpc, connect_sync, read_sync, write_sync, connect, Server
+from .sizeof import sizeof
 from .utils import funcname
 
 _ncores = ThreadPool()._processes
@@ -156,7 +157,7 @@ class Worker(Server):
             if not response == b'OK':
                 logger.warn('Could not report results of work to center: %s',
                             response.decode())
-            out = (b'OK', None)
+            out = (b'OK', {'nbytes': sizeof(result)})
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             tb = ''.join(traceback.format_tb(exc_traceback))


### PR DESCRIPTION
Experiments show that efficient nd-array operations require us to track the size of values in distributed memory and determine work locations to minimize communication.

For size computations we mostly depend on `sys.getsizeof` and the `__sizeof__` protocol, with a hacky `sizeof` `singledispatch` function for other cases.  Recent work in pandas supports this as well.

Most of this is adding an `nbytes` dictionary to scheduling state, adding various bits to the worker to produce and communicate this information, as well as fixes to other bugs that this uncovered.