### PR TITLE
Respect thread safety of tornado queues

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -402,8 +402,9 @@ def scheduler(scheduler_queue, report_queue, worker_queues, delete_queue,
             del worker_queues[worker]
             del ncores[worker]
             del stacks[worker]
-            logger.info("Lost all workers")
             del processing[worker]
+            if not stacks:
+                logger.critical("Lost all workers")
             missing_keys = set()
             for key in keys:
                 who_has[key].remove(worker)

--- a/distributed/tests/test_center.py
+++ b/distributed/tests/test_center.py
@@ -6,9 +6,10 @@ from tornado.ioloop import IOLoop
 
 from distributed.core import read, write, rpc
 from distributed.center import Center
+from distributed.utils_test import loop
 
 
-def test_metadata():
+def test_metadata(loop):
     c = Center('127.0.0.1', 8006)
     c.listen(8006)
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -2,7 +2,7 @@
 import dask
 import dask.dataframe as dd
 from distributed import Executor
-from distributed.utils_test import cluster, _test_cluster, slow
+from distributed.utils_test import cluster, _test_cluster, slow, loop
 from distributed.collections import (_futures_to_dask_dataframe,
         futures_to_dask_dataframe, _futures_to_dask_array,
         futures_to_dask_array)
@@ -31,7 +31,7 @@ def assert_equal(a, b):
         assert a == b
 
 
-def test__futures_to_dask_dataframe():
+def test__futures_to_dask_dataframe(loop):
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False)
@@ -51,7 +51,7 @@ def test__futures_to_dask_dataframe():
     _test_cluster(f)
 
 
-def test_futures_to_dask_dataframe():
+def test_futures_to_dask_dataframe(loop):
     with cluster() as (c, [a, b]):
         with Executor(('127.0.0.1', c['port'])) as e:
             remote_dfs = e.map(lambda x: x, dfs)
@@ -62,7 +62,7 @@ def test_futures_to_dask_dataframe():
 
 
 @slow
-def test_dataframes():
+def test_dataframes(loop):
     dfs = [pd.DataFrame({'x': np.random.random(100),
                          'y': np.random.random(100)},
                         index=list(range(i, i + 100)))
@@ -93,7 +93,7 @@ def test_dataframes():
                 assert_equal(local, remote)
 
 
-def test__futures_to_dask_array():
+def test__futures_to_dask_array(loop):
     import dask.array as da
     @gen.coroutine
     def f(c, a, b):
@@ -118,7 +118,7 @@ def test__futures_to_dask_array():
     _test_cluster(f)
 
 
-def test__dask_array_collections():
+def test__dask_array_collections(loop):
     import dask.array as da
     @gen.coroutine
     def f(c, a, b):
@@ -159,7 +159,7 @@ def test__dask_array_collections():
     _test_cluster(f)
 
 
-def test_futures_to_dask_array():
+def test_futures_to_dask_array(loop):
     with cluster() as (c, [a, b]):
         with Executor(('127.0.0.1', c['port'])) as e:
             remote_arrays = [[e.submit(np.full, (3, 3), i + j)

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -7,9 +7,9 @@ import pytest
 
 from distributed.core import (read, write, pingpong, read_sync, write_sync,
         Server, connect_sync, rpc, connect)
-from distributed.utils_test import slow
+from distributed.utils_test import slow, loop
 
-def test_server():
+def test_server(loop):
     @gen.coroutine
     def f():
         server = Server({'ping': pingpong})
@@ -27,10 +27,10 @@ def test_server():
 
         server.stop()
 
-    ioloop.IOLoop.current().run_sync(f)
+    loop.run_sync(f)
 
 
-def test_rpc():
+def test_rpc(loop):
     @gen.coroutine
     def f():
         server = Server({'ping': pingpong})
@@ -46,10 +46,10 @@ def test_rpc():
 
         server.stop()
 
-    ioloop.IOLoop.current().run_sync(f)
+    loop.run_sync(f)
 
 
-def test_rpc_with_many_connections():
+def test_rpc_with_many_connections(loop):
     remote = rpc(ip='127.0.0.1', port=8887)
 
     @gen.coroutine
@@ -69,10 +69,10 @@ def test_rpc_with_many_connections():
         remote.close_streams()
         assert all(stream.closed() for stream in remote.streams)
 
-    ioloop.IOLoop.current().run_sync(f)
+    loop.run_sync(f)
 
 
-def test_sync():
+def test_sync(loop):
     def f():
         from distributed.core import Server
         from tornado.ioloop import IOLoop
@@ -94,7 +94,7 @@ def test_sync():
 
 
 @slow
-def test_large_packets():
+def test_large_packets(loop):
     """ tornado has a 100MB cap by default """
     def echo(stream, x):
         return x
@@ -112,7 +112,7 @@ def test_large_packets():
 
         server.stop()
 
-    ioloop.IOLoop.current().run_sync(f)
+    loop.run_sync(f)
 
 
 def test_connect_sync_timeouts():

--- a/distributed/tests/test_dask.py
+++ b/distributed/tests/test_dask.py
@@ -8,7 +8,7 @@ from distributed import Center, Worker
 from distributed.utils import ignoring
 from distributed.client import RemoteData
 from distributed.dask import _get
-from distributed.utils_test import cluster, inc
+from distributed.utils_test import cluster, inc, loop
 
 from tornado import gen
 from tornado.ioloop import IOLoop
@@ -39,7 +39,7 @@ def _test_cluster(f):
     IOLoop.current().run_sync(g)
 
 
-def test_scheduler():
+def test_scheduler(loop):
     dsk = {'x': 1, 'y': (add, 'x', 10), 'z': (add, (inc, 'y'), 20),
            'a': 1, 'b': (mul, 'a', 10), 'c': (mul, 'b', 20),
            'total': (add, 'c', 'z')}
@@ -56,7 +56,7 @@ def test_scheduler():
     _test_cluster(f)
 
 
-def test_scheduler_errors():
+def test_scheduler_errors(loop):
     def mydiv(x, y):
         return x / y
     dsk = {'x': 1, 'y': (mydiv, 'x', 0)}
@@ -74,7 +74,7 @@ def test_scheduler_errors():
     _test_cluster(f)
 
 
-def test_avoid_computations_for_data_in_memory():
+def test_avoid_computations_for_data_in_memory(loop):
     def bad():
         raise Exception()
     dsk = {'x': (bad,), 'y': (inc, 'x'), 'z': (inc, 'y')}
@@ -92,7 +92,7 @@ def test_avoid_computations_for_data_in_memory():
     _test_cluster(f)
 
 
-def test_gather():
+def test_gather(loop):
     dsk = {'x': 1, 'y': (inc, 'x')}
     keys = 'y'
 
@@ -110,7 +110,7 @@ def slowinc(x):
     return x + 1
 
 
-def dont_test_failing_worker():
+def dont_test_failing_worker(loop):
     n = 10
     dsk = {('x', i, j): (slowinc, ('x', i, j - 1)) for i in range(4)
                                                    for j in range(1, n)}
@@ -133,7 +133,7 @@ def dont_test_failing_worker():
         IOLoop.current().run_sync(f)
 
 
-def test_repeated_computation():
+def test_repeated_computation(loop):
     from random import randint
     def func():
         return randint(0, 100)
@@ -149,7 +149,7 @@ def test_repeated_computation():
     _test_cluster(f)
 
 
-def test_RemoteData_interaction():
+def test_RemoteData_interaction(loop):
     @gen.coroutine
     def f(c, a, b):
         a.data['x'] = 10
@@ -166,7 +166,7 @@ def test_RemoteData_interaction():
     _test_cluster(f)
 
 
-def test_get_with_overlapping_keys():
+def test_get_with_overlapping_keys(loop):
     dsk = {'x': 1, 'y': (inc, 'x'), 'z': (inc, 'y')}
     keys = 'y'
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,9 +1,10 @@
 from distributed.utils import All
+from distributed.utils_test import loop
 from tornado import gen
 from tornado.ioloop import IOLoop
 from time import time
 
-def test_All():
+def test_All(loop):
     @gen.coroutine
     def throws():
         1 / 0
@@ -32,5 +33,4 @@ def test_All():
             end = time()
             assert end - start < 10
 
-    IOLoop.current().run_sync(f)
-
+    loop.run_sync(f)

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1,6 +1,6 @@
-from distributed.utils_test import cluster
+from distributed.utils_test import cluster, loop
 
-def test_cluster():
+def test_cluster(loop):
     with cluster() as (c, [a, b]):
         pass
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -6,6 +6,7 @@ from distributed.core import read, write, rpc, connect
 from distributed.sizeof import sizeof
 from distributed.utils import ignoring
 from distributed.worker import Worker
+from distributed.utils_test import loop
 
 
 from tornado import gen
@@ -44,7 +45,7 @@ def test_worker_ncores():
     w.terminate()
 
 
-def test_worker():
+def test_worker(loop):
     @gen.coroutine
     def f(c, a, b):
         aa = rpc(ip=a.ip, port=a.port)
@@ -85,7 +86,7 @@ def test_worker():
     _test_cluster(f)
 
 
-def test_workers_update_center():
+def test_workers_update_center(loop):
     @gen.coroutine
     def f(c, a, b):
         aa = rpc(ip=a.ip, port=a.port)
@@ -107,7 +108,8 @@ def test_workers_update_center():
 
     _test_cluster(f)
 
-def test_delete_data_with_missing_worker():
+
+def test_delete_data_with_missing_worker(loop):
     @gen.coroutine
     def f(c, a, b):
         bad = ('127.0.0.1', 9001)  # this worker doesn't exist

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -83,4 +83,4 @@ def sync(loop, func, *args, **kwargs):
 
 import logging
 logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s',
-                    level=logging.INFO)
+                    level=logging.DEBUG)


### PR DESCRIPTION
This commit includes two large changes:

1.  Instead of using `queue.put_nowait(...)` across threads
    we use `loop.add_callback(queue.put_nowait, ...)`
    See http://stackoverflow.com/questions/33105190/are-single-producer-consumer-tornado-queues-thread-safe
2.  We use a new IOLoop for every test.  We implement this as a pytest
    yield fixture

We also cleaned up a lot of tiny errors that were triggered by these
changes.