### PR TITLE
Refactor HLG materialization and processing into a shared utility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install dask branch
         shell: bash -l {0}
-        run: python -m pip install --no-deps git+https://github.com/rjzamora/dask@nuke-hlg
+        run: python -m pip install --no-deps git+https://github.com/mrocklin/dask@nuke-hlg
 
       - name: Install
         shell: bash -l {0}

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -101,6 +101,7 @@ from distributed.utils_comm import (
     scatter_to_workers,
     unpack_remotedata,
 )
+from distributed.utils_hlg import _materialize_and_process_hlg
 from distributed.worker import get_client, get_worker, secede
 
 logger = logging.getLogger(__name__)
@@ -2904,44 +2905,71 @@ class Client(SyncMethodMixin):
             # Create futures before sending graph (helps avoid contention)
             futures = {key: Future(key, self, inform=False) for key in keyset}
 
-            # TODO: Need to preserve the option to materialize the
-            # graph here and send it to the scheduler without Pickle
-            if self.scheduler.address.startswith("inproc://"):
-                kwargs = {"graph": dsk}
-            else:
-                buffers = []
-                out = pickle.dumps(dsk, buffer_callback=buffers.append)
-                buffers = [buffer.raw() for buffer in buffers]
-                nbytes = len(out) + sum(map(len, buffers))
-                if nbytes > 10_000_000:
-                    warnings.warn(
-                        f"Sending large graph of {format_bytes(nbytes)}.\n"
-                        "This may cause some slowdown.\n"
-                        "Consider scattering data ahead of time and using futures."
-                    )
-                kwargs = {
-                    "graph_header": out,
-                    "graph_frames": buffers,
-                }
+            # Construct _send_to_scheduler argument
+            if dask.config.get("distributed.scheduler.pickle"):
+                # TODO: This config value may vary between
+                # client and scheduler. Is this okay?
 
-            self._send_to_scheduler(
-                {
-                    "op": "update-graph-hlg",
-                    "keys": list(map(stringify, keys)),
-                    "priority": priority,
-                    "submitting_task": getattr(thread_state, "key", None),
-                    "fifo_timeout": fifo_timeout,
-                    "actors": actors,
-                    "code": self._get_computation_code(),
-                    "retries": retries,
-                    "resources": resources,
-                    "user_priority": user_priority,
-                    "workers": workers,
-                    "allow_other_workers": allow_other_workers,
-                    "annotations": annotations,
-                    **kwargs,
-                }
-            )
+                # Send HLG to the scheduler
+                if self.scheduler.address.startswith("inproc://"):
+                    kwargs = {"graph": dsk}
+                else:
+                    buffers = []
+                    out = pickle.dumps(dsk, buffer_callback=buffers.append)
+                    buffers = [buffer.raw() for buffer in buffers]
+                    nbytes = len(out) + sum(map(len, buffers))
+                    if nbytes > 10_000_000:
+                        warnings.warn(
+                            f"Sending large graph of {format_bytes(nbytes)}.\n"
+                            "This may cause some slowdown.\n"
+                            "Consider scattering data ahead of time and using futures."
+                        )
+                    kwargs = {
+                        "graph_header": out,
+                        "graph_frames": buffers,
+                    }
+
+                self._send_to_scheduler(
+                    {
+                        "op": "update-graph-hlg",
+                        "keys": list(map(stringify, keys)),
+                        "priority": priority,
+                        "submitting_task": getattr(thread_state, "key", None),
+                        "fifo_timeout": fifo_timeout,
+                        "actors": actors,
+                        "code": self._get_computation_code(),
+                        "retries": retries,
+                        "resources": resources,
+                        "user_priority": user_priority,
+                        "workers": workers,
+                        "allow_other_workers": allow_other_workers,
+                        "annotations": annotations,
+                        **kwargs,
+                    }
+                )
+            else:
+                # Send materialized graph to the scheduler
+                self._send_to_scheduler(
+                    {
+                        "op": "update-graph",
+                        "submitting_task": getattr(thread_state, "key", None),
+                        "fifo_timeout": fifo_timeout,
+                        "actors": actors,
+                        "code": self._get_computation_code(),
+                        "stimulus_id": f"update-graph-{time()}",
+                        **_materialize_and_process_hlg(
+                            dsk,
+                            keys,
+                            priority=priority,
+                            resources=resources,
+                            retries=retries,
+                            user_priority=user_priority,
+                            workers=workers,
+                            allow_other_workers=allow_other_workers,
+                            annotations=annotations,
+                        ),
+                    }
+                )
             return futures
 
     def get(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -37,7 +37,6 @@ from sortedcontainers import SortedDict, SortedSet
 from tlz import (
     first,
     groupby,
-    keymap,
     merge,
     merge_sorted,
     merge_with,
@@ -49,16 +48,8 @@ from tlz import (
 from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
-from dask.core import get_deps
 from dask.highlevelgraph import HighLevelGraph
-from dask.utils import (
-    format_bytes,
-    format_time,
-    parse_bytes,
-    parse_timedelta,
-    stringify,
-    tmpfile,
-)
+from dask.utils import format_bytes, format_time, parse_bytes, parse_timedelta, tmpfile
 from dask.widgets import get_template
 
 from distributed import cluster_dump, preloading, profile
@@ -112,6 +103,7 @@ from distributed.utils_comm import (
     retry_operation,
     scatter_to_workers,
 )
+from distributed.utils_hlg import _materialize_and_process_hlg
 from distributed.utils_perf import disable_gc_diagnosis, enable_gc_diagnosis
 from distributed.variable import VariableExtension
 
@@ -3833,158 +3825,27 @@ class Scheduler(SchedulerState, ServerNode):
         else:
             graph_ = graph
 
-        if annotations is None:
-            annotations = {}
-
-        workers = workers or annotations.pop("workers", None)
-        allow_other_workers = allow_other_workers or annotations.pop(
-            "allow_other_workers", None
+        # Materialize the HLG and extract graph-related info
+        hlg_info = _materialize_and_process_hlg(
+            graph_,
+            keys,
+            priority=priority,
+            resources=resources,
+            retries=retries,
+            user_priority=user_priority,
+            workers=workers,
+            allow_other_workers=allow_other_workers,
+            annotations=annotations,
         )
-        if retries is None:
-            retries = annotations.pop("retries", None)
-        resources = resources or annotations.pop("resources", None)
-        user_priority = annotations.pop("priority", user_priority)
-
-        if isinstance(workers, (str, Number)):
-            workers = [workers]
-        if isinstance(workers, (tuple, set)):
-            workers = list(workers)
-        if isinstance(workers, list):
-            restrictions = workers
-        elif workers is None:
-            restrictions = []
-        else:
-            raise TypeError("Workers must be a list or set of workers or None")
-
-        dsk = dict(graph_)
-
-        if allow_other_workers:
-            loose_restrictions = set(dsk)
-        else:
-            loose_restrictions = set()
-
-        from distributed.utils_comm import unpack_remotedata
-
-        dependencies, dependents = get_deps(dsk)
-
-        # Remove `Future` objects from graph and note any future     dependencies
-        dsk2 = {}
-        fut_deps = {}
-        for k, v in dsk.items():
-            dsk2[k], futs = unpack_remotedata(v, byte_keys=True)
-            if futs:
-                fut_deps[k] = futs
-        dsk = dsk2
-
-        # - Add in deps for any tasks that depend on futures
-        for k, futures in fut_deps.items():
-            dependencies[k].update(f.key for f in futures)
-
-        pre_stringify = set(dsk)
-        dsk = {stringify(k): stringify(v, exclusive=graph_) for k, v in dsk.items()}
-
-        def process(x, keys=dsk, string_keys=pre_stringify):
-            if callable(x):
-                return {stringify(k): x(k) for k in keys}
-            elif isinstance(x, (int, dict, tuple, set, list)):
-                return {stringify(k): x for k in string_keys or map(stringify, keys)}
-            elif isinstance(x, dict):
-                return keymap(stringify, x)
-            raise TypeError()
-
-        if annotations:
-            annotations = process(annotations)
-        if retries:
-            retries = process(retries)
-        if resources:
-            resources = process(resources)
-        if user_priority:
-            user_priority = process(user_priority)
-        if restrictions:
-            _restrictions = process(restrictions)
-        else:
-            _restrictions = {}
-
-        for layer in graph_.layers.values():
-            if not layer.annotations:
-                continue
-            layer_annotations: dict = dict(layer.annotations)
-            if "retries" in layer_annotations:
-                retries = retries or {}
-                d = process(layer_annotations["retries"], keys=layer, string_keys=None)
-                retries.update(d)  # TODO: there is an implicit ordering here
-            if "priority" in layer_annotations:
-                user_priority = user_priority or {}
-                d = process(
-                    layer_annotations.pop("priority"),
-                    keys=layer,
-                    string_keys=None,
-                )
-                user_priority.update(d)  # TODO: there is an implicit ordering here
-            if "resources" in layer_annotations:
-                resources = resources or {}
-                d = process(
-                    layer_annotations["resources"], keys=layer, string_keys=None
-                )
-                resources.update(d)  # TODO: there is an implicit ordering here
-            if "workers" in layer_annotations:
-                if isinstance(layer_annotations["workers"], (str, int)):
-                    layer_annotations["workers"] = (layer_annotations["workers"],)
-                _restrictions = _restrictions or {}
-                d = process(layer_annotations["workers"], keys=layer, string_keys=None)
-                _restrictions.update(d)  # TODO: there is an implicit ordering here
-
-            if "allow_other_workers" in layer_annotations:
-                if layer_annotations["allow_other_workers"] is True:
-                    loose_restrictions.update(set(map(stringify, layer)))
-
-            if layer_annotations:
-                d = process(layer_annotations, keys=layer, string_keys=None)
-                annotations.update(d)
-
-        from distributed.worker import dumps_task
-
-        dsk = valmap(dumps_task, dsk)
-
-        dependencies = {
-            stringify(k): {stringify(dep) for dep in deps}
-            for k, deps in dependencies.items()
-        }
-
-        # Remove any self-dependencies (happens on test_publish_bag() and others)
-        for k, v in dependencies.items():
-            deps = set(v)
-            if k in deps:
-                deps.remove(k)
-            dependencies[k] = deps
-
-        if priority is None:
-            # Removing all non-local keys before calling order()
-            dsk_keys = set(dsk)  # intersection() of sets is much faster than dict_keys
-            stripped_deps = {
-                k: v.intersection(dsk_keys)
-                for k, v in dependencies.items()
-                if k in dsk_keys
-            }
-            priority = dask.order.order(dsk, dependencies=stripped_deps)
 
         return self.update_graph(
-            client,
-            dsk,
-            keys,
-            dependencies,
-            _restrictions,
-            priority,
-            loose_restrictions,
-            resources,
-            submitting_task,
-            retries,
-            user_priority,
-            actors,
-            fifo_timeout,
-            annotations,
+            client=client,
+            submitting_task=submitting_task,
+            actors=actors,
+            fifo_timeout=fifo_timeout,
             code=code,
             stimulus_id=f"update-graph-{time()}",
+            **hlg_info,
         )
 
     def update_graph(

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2668,7 +2668,12 @@ async def test_run_spec_deserialize_fail(c, s, a, b):
         def __reduce__(self):
             return lambda: 1 / 0, ()
 
-    with captured_logger("distributed.worker") as logger:
+    # Must dissable pickle on the scheduler to
+    # ensure 'Could not deserialize task' is
+    # written to the worker log
+    with captured_logger("distributed.worker") as logger, dask.config.set(
+        {"distributed.scheduler.pickle": False}
+    ):
         fut = c.submit(F())
         assert isinstance(await fut.exception(), ZeroDivisionError)
 

--- a/distributed/utils_hlg.py
+++ b/distributed/utils_hlg.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from numbers import Number
+
+from tlz import keymap, valmap
+
+import dask
+from dask.core import get_deps
+from dask.highlevelgraph import HighLevelGraph
+from dask.utils import stringify
+
+
+def _materialize_and_process_hlg(
+    hlg: HighLevelGraph,
+    keys: list[str],
+    priority=None,
+    resources=None,
+    retries=None,
+    user_priority=0,
+    workers=None,
+    allow_other_workers=None,
+    annotations=None,
+) -> dict:
+    """Materialize and process a HighLevelGraph object
+
+    The output of this function is a dictionary of (most)
+    key-word arguments to ``distributed.scheduler.update_graph``.
+    """
+
+    from distributed.utils_comm import unpack_remotedata
+    from distributed.worker import dumps_task
+
+    if annotations is None:
+        annotations = {}
+
+    workers = workers or annotations.pop("workers", None)
+    allow_other_workers = allow_other_workers or annotations.pop(
+        "allow_other_workers", None
+    )
+    if retries is None:
+        retries = annotations.pop("retries", None)
+    resources = resources or annotations.pop("resources", None)
+    user_priority = annotations.pop("priority", user_priority)
+
+    if isinstance(workers, (str, Number)):
+        workers = [workers]
+    if isinstance(workers, (tuple, set)):
+        workers = list(workers)
+    if isinstance(workers, list):
+        restrictions = workers
+    elif workers is None:
+        restrictions = []
+    else:
+        raise TypeError("Workers must be a list or set of workers or None")
+
+    # Materialized the HLG
+    dsk = dict(hlg)
+
+    if allow_other_workers:
+        loose_restrictions = set(dsk)
+    else:
+        loose_restrictions = set()
+
+    dependencies, dependents = get_deps(dsk)
+
+    # Remove `Future` objects from graph and note any future dependencies
+    dsk2 = {}
+    fut_deps = {}
+    for k, v in dsk.items():
+        dsk2[k], futs = unpack_remotedata(v, byte_keys=True)
+        if futs:
+            fut_deps[k] = futs
+    dsk = dsk2
+
+    # - Add in deps for any tasks that depend on futures
+    for k, futures in fut_deps.items():
+        dependencies[k].update(f.key for f in futures)
+
+    pre_stringify = set(dsk)
+    dsk = {stringify(k): stringify(v, exclusive=hlg) for k, v in dsk.items()}
+
+    def process(x, keys=dsk, string_keys=pre_stringify):
+        if callable(x):
+            return {stringify(k): x(k) for k in keys}
+        elif isinstance(x, (int, dict, tuple, set, list)):
+            return {stringify(k): x for k in string_keys or map(stringify, keys)}
+        elif isinstance(x, dict):
+            return keymap(stringify, x)
+        raise TypeError()
+
+    if annotations:
+        annotations = process(annotations)
+    if retries:
+        retries = process(retries)
+    if resources:
+        resources = process(resources)
+    if user_priority:
+        user_priority = process(user_priority)
+    if restrictions:
+        _restrictions = process(restrictions)
+    else:
+        _restrictions = {}
+
+    for layer in hlg.layers.values():
+        if not layer.annotations:
+            continue
+        layer_annotations: dict = dict(layer.annotations)
+        if "retries" in layer_annotations:
+            retries = retries or {}
+            d = process(layer_annotations["retries"], keys=layer, string_keys=None)
+            retries.update(d)  # TODO: there is an implicit ordering here
+        if "priority" in layer_annotations:
+            user_priority = user_priority or {}
+            d = process(
+                layer_annotations.pop("priority"),
+                keys=layer,
+                string_keys=None,
+            )
+            user_priority.update(d)  # TODO: there is an implicit ordering here
+        if "resources" in layer_annotations:
+            resources = resources or {}
+            d = process(layer_annotations["resources"], keys=layer, string_keys=None)
+            resources.update(d)  # TODO: there is an implicit ordering here
+        if "workers" in layer_annotations:
+            if isinstance(layer_annotations["workers"], (str, int)):
+                layer_annotations["workers"] = (layer_annotations["workers"],)
+            _restrictions = _restrictions or {}
+            d = process(layer_annotations["workers"], keys=layer, string_keys=None)
+            _restrictions.update(d)  # TODO: there is an implicit ordering here
+
+        if "allow_other_workers" in layer_annotations:
+            if layer_annotations["allow_other_workers"] is True:
+                loose_restrictions.update(set(map(stringify, layer)))
+
+        if layer_annotations:
+            d = process(layer_annotations, keys=layer, string_keys=None)
+            annotations.update(d)
+
+    dsk = valmap(dumps_task, dsk)
+
+    dependencies = {
+        stringify(k): {stringify(dep) for dep in deps}
+        for k, deps in dependencies.items()
+    }
+
+    # Remove any self-dependencies (happens on test_publish_bag() and others)
+    for k, v in dependencies.items():
+        deps = set(v)
+        if k in deps:
+            deps.remove(k)
+        dependencies[k] = deps
+
+    if priority is None:
+        # Removing all non-local keys before calling order()
+        dsk_keys = set(dsk)  # intersection() of sets is much faster than dict_keys
+        stripped_deps = {
+            k: v.intersection(dsk_keys)
+            for k, v in dependencies.items()
+            if k in dsk_keys
+        }
+        priority = dask.order.order(dsk, dependencies=stripped_deps)
+
+    # Return (most) graph-dependent scheduler.update_graph kwargs
+    return dict(
+        tasks=dsk,
+        keys=keys,
+        dependencies=dependencies,
+        restrictions=_restrictions,
+        priority=priority,
+        loose_restrictions=loose_restrictions,
+        resources=resources,
+        retries=retries,
+        user_priority=user_priority,
+        annotations=annotations,
+    )

--- a/distributed/utils_hlg.py
+++ b/distributed/utils_hlg.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from numbers import Number
+from typing import Any
 
 from tlz import keymap, valmap
 
@@ -13,13 +14,13 @@ from dask.utils import stringify
 def _materialize_and_process_hlg(
     hlg: HighLevelGraph,
     keys: list[str],
-    priority=None,
-    resources=None,
-    retries=None,
-    user_priority=0,
-    workers=None,
-    allow_other_workers=None,
-    annotations=None,
+    priority: dict | None = None,
+    resources: dict | None = None,
+    retries: dict | None = None,
+    user_priority: dict | None = None,
+    workers: Any = None,
+    allow_other_workers: Any = None,
+    annotations: dict | None = None,
 ) -> dict:
     """Materialize and process a HighLevelGraph object
 
@@ -30,8 +31,7 @@ def _materialize_and_process_hlg(
     from distributed.utils_comm import unpack_remotedata
     from distributed.worker import dumps_task
 
-    if annotations is None:
-        annotations = {}
+    annotations = annotations or {}
 
     workers = workers or annotations.pop("workers", None)
     allow_other_workers = allow_other_workers or annotations.pop(
@@ -134,6 +134,7 @@ def _materialize_and_process_hlg(
 
         if layer_annotations:
             d = process(layer_annotations, keys=layer, string_keys=None)
+            annotations = annotations or {}
             annotations.update(d)
 
     dsk = valmap(dumps_task, dsk)
@@ -170,6 +171,6 @@ def _materialize_and_process_hlg(
         loose_restrictions=loose_restrictions,
         resources=resources,
         retries=retries,
-        user_priority=user_priority,
+        user_priority=user_priority or 0,
         annotations=annotations,
     )


### PR DESCRIPTION
Uses `"update-graph"` instead of `"update-graph-hlg"` when the `"distributed.scheduler.pickle"` config is `False`. This just runs the same graph materialization and processing code on client instead of on the scheduler. 

Note that we **may** want to use a config option that is distinct from scheduler/pickle, since the real decision is whether to materialize the graph on the client or scheduler.

@mrocklin - I know you didn't plan to support the "non-pickle" code path.  However, this seems like a relatively simple escape hatch to support for now? Let me know what you think.